### PR TITLE
ASDK-175955: Updated SDK Guide links

### DIFF
--- a/docs/dev-centre/ws1/index.md
+++ b/docs/dev-centre/ws1/index.md
@@ -108,9 +108,9 @@ Additionally, documentation and guides are provided for APIs, SDKs and Powershel
   url: /workspace-one-uem-apis/
   image: ../../assets/logos/UEM-h-lm.png
 
-- title: Workspace ONE UEM SDK for Android
+- title: Workspace ONE SDK for Android
 
-  url: /ws1-uem-sdk-for-android/
+  url: /ws1-sdk-for-android/
   image: ../../assets/logos/SDK-v-lm.png
 
 - title: Workspace ONE UEM SDK for iOS

--- a/docs/sdks/index.md
+++ b/docs/sdks/index.md
@@ -27,7 +27,7 @@ Developers, Automation Engineers, and System Administrators can build world clas
 
 - title: Workspace ONE SDK for Android
   content: enable additional app config and security capabilities that may not yet be available natively as part of the AppConfig Community for Android devices
-  url: ../ws1-uem-sdk-for-android/index.md
+  url: ../ws1-sdk-for-android/index.md
   image: ../assets/logos/SDK-v-lm.png
 
 - title: Workspace ONE SDK for iOS


### PR DESCRIPTION
Since we Updated the name of Workspace one SDK to 
[WS1 SDK for Android](https://developer.omnissa.com/ws1-sdk-for-android/) instead of 
[WS1 UEM SDK for Android](https://developer.omnissa.com/ws1-uem-sdk-for-android/).

All links pointing to this page had to be updated. This Pr includes all of those changes.